### PR TITLE
Remove bullet usage and dependency by using ViSP instead. This was done ...

### DIFF
--- a/visp_tracker/CMakeLists.txt
+++ b/visp_tracker/CMakeLists.txt
@@ -3,10 +3,6 @@ project(visp_tracker)
 
 find_package(Boost REQUIRED COMPONENTS filesystem thread)
 
-# Look for Bullet
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(BULLET bullet)
-
 find_package(catkin REQUIRED COMPONENTS
   dynamic_reconfigure
   geometry_msgs
@@ -66,13 +62,11 @@ catkin_package(
    )
 
 include_directories(SYSTEM
-  ${BULLET_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
   ${VISP_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
   )
 link_directories(SYSTEM
-  ${BULLET_LIBRARY_DIRS}
   ${Boost_LIBRARY_DIRS}
   ${VISP_LIBRARY_DIRS}
   ${catkin_LIBRARY_DIRS}

--- a/visp_tracker/package.xml
+++ b/visp_tracker/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>visp_tracker</name>
-  <version>0.7.0</version>
+  <version>0.7.2</version>
   <description>
     Wraps the ViSP moving edge tracker provided by the ViSP visual
     servoing library into a ROS package.
@@ -21,7 +21,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>bullet</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>nodelet</build_depend>
@@ -36,7 +35,6 @@
   <build_depend>tf</build_depend>
   <build_depend>visp</build_depend>
 
-  <run_depend>bullet</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>message_generation</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>

--- a/visp_tracker/src/libvisp_tracker/conversion.cpp
+++ b/visp_tracker/src/libvisp_tracker/conversion.cpp
@@ -3,8 +3,6 @@
 
 #include <boost/format.hpp>
 
-#include <LinearMath/btMatrix3x3.h>
-#include <LinearMath/btQuaternion.h>
 #include <tf/transform_datatypes.h>
 
 #include <sensor_msgs/Image.h>
@@ -12,6 +10,8 @@
 #include <sensor_msgs/distortion_models.h>
 
 #include <visp/vpImage.h>
+#include <visp/vpTranslationVector.h>
+#include <visp/vpQuaternionVector.h>
 
 #define protected public
 # include <visp/vpMbEdgeTracker.h>
@@ -88,12 +88,8 @@ void vispImageToRos(sensor_msgs::Image& dst,
 void vpHomogeneousMatrixToTransform(geometry_msgs::Transform& dst,
 				    const vpHomogeneousMatrix& src)
 {
-  btMatrix3x3 rotation;
-  btQuaternion quaternion;
-  for(unsigned i = 0; i < 3; ++i)
-    for(unsigned j = 0; j < 3; ++j)
-      rotation[i][j] = src[i][j];
-  rotation.getRotation(quaternion);
+  vpQuaternionVector quaternion;
+  src.extract(quaternion);
 
   dst.translation.x = src[0][3];
   dst.translation.y = src[1][3];
@@ -108,28 +104,18 @@ void vpHomogeneousMatrixToTransform(geometry_msgs::Transform& dst,
 void transformToVpHomogeneousMatrix(vpHomogeneousMatrix& dst,
 				    const geometry_msgs::Transform& src)
 {
-  btQuaternion quaternion
-    (src.rotation.x, src.rotation.y, src.rotation.z, src.rotation.w);
-  btMatrix3x3 rotation(quaternion);
-
-  // Copy the rotation component.
-  for(unsigned i = 0; i < 3; ++i)
-    for(unsigned j = 0; j < 3; ++j)
-      dst[i][j] = rotation[i][j];
-
-  // Copy the translation component.
-  dst[0][3] = src.translation.x;
-  dst[1][3] = src.translation.y;
-  dst[2][3] = src.translation.z;
+  vpTranslationVector translation(src.translation.x,src.translation.y,src.translation.z);
+  vpQuaternionVector quaternion(src.rotation.x,src.rotation.y,src.rotation.z,src.rotation.w);
+  dst.buildFrom(translation, quaternion);
 }
 
 void transformToVpHomogeneousMatrix(vpHomogeneousMatrix& dst,
 				    const geometry_msgs::Pose& src)
 {
-  btQuaternion quaternion
+  vpQuaternionVector quaternion
     (src.orientation.x, src.orientation.y, src.orientation.z,
      src.orientation.w);
-  btMatrix3x3 rotation(quaternion);
+  vpRotationMatrix rotation(quaternion);
 
   // Copy the rotation component.
   for(unsigned i = 0; i < 3; ++i)


### PR DESCRIPTION
...to avoid errors when releasing vision_visp on oneiric/groovy where bullet is not packaged.
