### PR TITLE
Fix compilation on 17.04 by adding missing boost/format.hpp inclusion

### DIFF
--- a/visp_camera_calibration/src/camera.cpp
+++ b/visp_camera_calibration/src/camera.cpp
@@ -62,6 +62,7 @@
 
 #include <visp/vpDisplayX.h>
 #include "visp/vpTrackingException.h"
+#include <boost/format.hpp>
 
 
 namespace visp_camera_calibration

--- a/visp_camera_calibration/src/image_processing.cpp
+++ b/visp_camera_calibration/src/image_processing.cpp
@@ -68,6 +68,7 @@
 #include "visp/vpDot.h"
 #include "visp/vpDot2.h"
 #include "visp/vpCalibration.h"
+#include <boost/format.hpp>
 #include <iostream>
 
 


### PR DESCRIPTION
On 17.04 with Lunar, compilation fails because <boost/format.hpp> is missing from the included headers. Probably something changed in Boost. This should not harm the compilation in previous Ubuntu versions.

This was apparently the only fix necessary to compile the whole ViSP in the new environment.. kudos! When can we expect the next bloom release? :innocent: 