### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/visp_tracker/src/nodelets/client.cpp
+++ b/visp_tracker/src/nodelets/client.cpp
@@ -56,5 +56,4 @@ namespace visp_tracker
 
 } // end of namespace visp_tracker.
 
-PLUGINLIB_DECLARE_CLASS(visp_tracker, TrackerClient,
-			visp_tracker::TrackerClientNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(visp_tracker::TrackerClientNodelet, nodelet::Nodelet)

--- a/visp_tracker/src/nodelets/tracker.cpp
+++ b/visp_tracker/src/nodelets/tracker.cpp
@@ -58,5 +58,4 @@ namespace visp_tracker
 
 } // end of namespace visp_tracker.
 
-PLUGINLIB_DECLARE_CLASS(visp_tracker, Tracker,
-			visp_tracker::TrackerNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(visp_tracker::TrackerNodelet, nodelet::Nodelet)

--- a/visp_tracker/src/nodelets/viewer.cpp
+++ b/visp_tracker/src/nodelets/viewer.cpp
@@ -56,5 +56,4 @@ namespace visp_tracker
 
 } // end of namespace visp_tracker.
 
-PLUGINLIB_DECLARE_CLASS(visp_tracker, TrackerViewer,
-			visp_tracker::TrackerViewerNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(visp_tracker::TrackerViewerNodelet, nodelet::Nodelet)


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions