### PR TITLE
Add April tags detector for visp_auto_tracker (with visp3)

### DIFF
--- a/visp_auto_tracker/CMakeLists.txt
+++ b/visp_auto_tracker/CMakeLists.txt
@@ -35,7 +35,7 @@ find_package(catkin REQUIRED COMPONENTS
 # see https://github.com/ros/catkin/issues/606
 find_package(VISP)
 
-if(VISP_HAVE_ZBAR OR VISP_HAVE_DMTX)
+if(VISP_HAVE_ZBAR OR VISP_HAVE_DMTX OR VISP_HAVE_APRILTAG)
 
 # Boost signals component is no longer being actively maintained since boost 1.63.0
 # Keept here as optional for compat with older ROS versions, but for Neotic this component is useless.
@@ -213,7 +213,7 @@ if(CATKIN_ENABLE_TESTING)
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
   )
 endif()
-else() # VISP_HAVE_ZBAR OR VISP_HAVE_DMTX
+else() # VISP_HAVE_ZBAR OR VISP_HAVE_DMTX OR VISP_HAVE_APRILTAG
 message("${PROJECT_NAME} build is disabled since ViSP is not built with libzbar-dev 3rd party")
-endif() # VISP_HAVE_ZBAR OR VISP_HAVE_DMTX
+endif() # VISP_HAVE_ZBAR OR VISP_HAVE_DMTX OR VISP_HAVE_APRILTAG
 

--- a/visp_auto_tracker/README.md
+++ b/visp_auto_tracker/README.md
@@ -3,7 +3,7 @@
 
 visp_auto_tracker wraps model-based trackers provided by ViSP visual 
 servoing library into a ROS package. The tracked object should have a 
-QRcode of Flash code pattern. Based on the pattern, the object is 
+QRcode, Flash code or April tag pattern. Based on the pattern, the object is 
 automaticaly detected. The detection allows then to initialise the 
 model-based trackers. When lost of tracking achieves a new detection 
 is performed that will be used to re-initialize the tracker.
@@ -13,7 +13,7 @@ orientation) of an object in an image. It is fast enough to allow
 object online tracking using a camera.
 
 This package is composed of one node called 'visp_auto_tracker'. The 
-node tries first to detect the QRcode or the Flash code associated to 
+node tries first to detect the QRcode, the Flash or the April tag code associated to 
 the object. Once the detection is performed, the node tracks the object. 
 When a lost of tracking occurs the node tries to detect once again the 
 object and then restart a tracking.

--- a/visp_auto_tracker/flashcode_mbt/README
+++ b/visp_auto_tracker/flashcode_mbt/README
@@ -36,7 +36,8 @@ General options:
   -P [ --pattern-name ] arg (=pattern)  name of xml,init and wrl files
   -r [ --detector-type ] arg (=zbar)    Type of your detector that will be used
                                         for initialisation/recovery. zbar for 
-                                        QRcodes and more, dtmx for flashcodes.
+                                        QRcodes and more, dtmx for flashcodes,
+                                        april for April tags.
   -t [ --tracker-type ] arg (=klt_mbt)  Type of tracker. mbt_klt for hybrid: 
                                         mbt+klt, mbt for model based, klt for 
                                         klt-based

--- a/visp_auto_tracker/flashcode_mbt/README
+++ b/visp_auto_tracker/flashcode_mbt/README
@@ -38,6 +38,9 @@ General options:
                                         for initialisation/recovery. zbar for 
                                         QRcodes and more, dtmx for flashcodes,
                                         april for April tags.
+  -u [ --detector-subtype ] arg         Subtype of your detector that will be 
+                                        used for initialisation/recovery. For 
+                                        april detector: 36h11, 16h5, ...
   -t [ --tracker-type ] arg (=klt_mbt)  Type of tracker. mbt_klt for hybrid: 
                                         mbt+klt, mbt for model based, klt for 
                                         klt-based

--- a/visp_auto_tracker/flashcode_mbt/cmd_line/cmd_line.cpp
+++ b/visp_auto_tracker/flashcode_mbt/cmd_line/cmd_line.cpp
@@ -112,6 +112,9 @@ void CmdLine::loadConfig(std::string& config_file){
     case DMTX:
       std::cout << "Datamatrix (flashcode)";
       break;
+    case APRIL:
+      std::cout << "April tags";
+      break;
     }
     std::cout << std::endl;
 
@@ -307,6 +310,8 @@ std::vector<vpPoint>& CmdLine:: get_outer_points_3D() {
 CmdLine::DETECTOR_TYPE CmdLine:: get_detector_type() const{
   if(vm_["detector-type"].as<std::string>()=="zbar")
     return CmdLine::ZBAR;
+  else if(vm_["detector-type"].as<std::string>()=="april")
+    return CmdLine::APRIL;
   else
     return CmdLine::DMTX;
 }

--- a/visp_auto_tracker/flashcode_mbt/cmd_line/cmd_line.cpp
+++ b/visp_auto_tracker/flashcode_mbt/cmd_line/cmd_line.cpp
@@ -17,7 +17,7 @@ void CmdLine::common(){
       ("video-output-path,L", po::value<std::string>(&log_file_pattern_),"output video file path relative to the data directory")
       ("single-image,I", po::value<std::string>(&single_image_name_),"load this single image (relative to data dir)")
       ("pattern-name,P", po::value<std::string>(&pattern_name_)->default_value("pattern"),"name of xml,init and wrl files")
-      ("detector-type,r", po::value<std::string>()->default_value("zbar"),"Type of your detector that will be used for initialisation/recovery. zbar for QRcodes and more, dmtx for flashcodes.")
+      ("detector-type,r", po::value<std::string>()->default_value("zbar"),"Type of your detector that will be used for initialisation/recovery. zbar for QRcodes and more, dmtx for flashcodes, april for April tags.")
       ("tracker-type,t", po::value<std::string>()->default_value("klt_mbt"),"Type of tracker. mbt_klt for hybrid: mbt+klt, mbt for model based, klt for klt-based")
       ("verbose,v", po::value< bool >(&verbose_)->default_value(false)->composing(), "Enable or disable additional printings")
       ("dmx-detector-timeout,T", po::value<int>(&dmx_timeout_)->default_value(1000), "timeout for datamatrix detection in ms")

--- a/visp_auto_tracker/flashcode_mbt/cmd_line/cmd_line.cpp
+++ b/visp_auto_tracker/flashcode_mbt/cmd_line/cmd_line.cpp
@@ -18,6 +18,7 @@ void CmdLine::common(){
       ("single-image,I", po::value<std::string>(&single_image_name_),"load this single image (relative to data dir)")
       ("pattern-name,P", po::value<std::string>(&pattern_name_)->default_value("pattern"),"name of xml,init and wrl files")
       ("detector-type,r", po::value<std::string>()->default_value("zbar"),"Type of your detector that will be used for initialisation/recovery. zbar for QRcodes and more, dmtx for flashcodes, april for April tags.")
+      ("detector-subtype,u", po::value<std::string>(&detector_subtype_)->default_value(""),"Subtype of your detector that will be used for initialisation/recovery. For april detector : 36h11, 16h5, ...")
       ("tracker-type,t", po::value<std::string>()->default_value("klt_mbt"),"Type of tracker. mbt_klt for hybrid: mbt+klt, mbt for model based, klt for klt-based")
       ("verbose,v", po::value< bool >(&verbose_)->default_value(false)->composing(), "Enable or disable additional printings")
       ("dmx-detector-timeout,T", po::value<int>(&dmx_timeout_)->default_value(1000), "timeout for datamatrix detection in ms")
@@ -314,6 +315,10 @@ CmdLine::DETECTOR_TYPE CmdLine:: get_detector_type() const{
     return CmdLine::APRIL;
   else
     return CmdLine::DMTX;
+}
+
+std::string CmdLine:: get_detector_subtype() const{
+  return detector_subtype_;
 }
 
 CmdLine::TRACKER_TYPE CmdLine:: get_tracker_type() const{

--- a/visp_auto_tracker/flashcode_mbt/cmd_line/cmd_line.h
+++ b/visp_auto_tracker/flashcode_mbt/cmd_line/cmd_line.h
@@ -36,6 +36,7 @@ private:
   double mbt_dynamic_range_;
   std::string data_dir_;
   std::string pattern_name_;
+  std::string detector_subtype_;
   std::string var_file_;
   std::string single_image_name_;
   std::vector<vpPoint> flashcode_points_3D_;
@@ -146,6 +147,8 @@ public:
   std::vector<vpPoint>& get_outer_points_3D();
 
   DETECTOR_TYPE get_detector_type() const;
+
+  std::string get_detector_subtype() const;
 
   TRACKER_TYPE get_tracker_type() const;
 

--- a/visp_auto_tracker/flashcode_mbt/cmd_line/cmd_line.h
+++ b/visp_auto_tracker/flashcode_mbt/cmd_line/cmd_line.h
@@ -51,7 +51,7 @@ private:
   void common();
 public:
   enum DETECTOR_TYPE{
-    DMTX, ZBAR
+    DMTX, ZBAR, APRIL
   };
   enum TRACKER_TYPE{
     KLT, MBT, KLT_MBT

--- a/visp_auto_tracker/package.xml
+++ b/visp_auto_tracker/package.xml
@@ -8,7 +8,7 @@
 
     visp_auto_tracker wraps model-based trackers provided by ViSP visual
     servoing library into a ROS package. The tracked object should have a
-    QRcode of Flash code pattern. Based on the pattern, the object is
+    QRcode, Flash code, or April tag pattern. Based on the pattern, the object is
     automaticaly detected. The detection allows then to initialise the
     model-based trackers. When lost of tracking achieves a new detection
     is performed that will be used to re-initialize the tracker.

--- a/visp_auto_tracker/src/node.cpp
+++ b/visp_auto_tracker/src/node.cpp
@@ -151,8 +151,23 @@ namespace visp_auto_tracker{
       detector = new vpDetectorQRCode;
     else if(cmd_.get_detector_type() == CmdLine::DMTX)
       detector = new vpDetectorDataMatrixCode;
-    else if(cmd_.get_detector_type() == CmdLine::APRIL)
-      detector = new vpDetectorAprilTag;
+    else if(cmd_.get_detector_type() == CmdLine::APRIL) {
+      vpDetectorAprilTag::vpAprilTagFamily tag_family = vpDetectorAprilTag::vpAprilTagFamily::TAG_36h11;
+      std::string tag_family_str = cmd_.get_detector_subtype();
+      if(tag_family_str.find("16h5") != std::string::npos)
+        tag_family = vpDetectorAprilTag::vpAprilTagFamily::TAG_16h5;
+      else if(tag_family_str.find("25h7") != std::string::npos)
+        tag_family = vpDetectorAprilTag::vpAprilTagFamily::TAG_25h7;
+      else if(tag_family_str.find("25h9") != std::string::npos)
+        tag_family = vpDetectorAprilTag::vpAprilTagFamily::TAG_25h9;
+      else if(tag_family_str.find("36ARTOOLKIT") != std::string::npos)
+        tag_family = vpDetectorAprilTag::vpAprilTagFamily::TAG_36ARTOOLKIT;
+      else if(tag_family_str.find("36h10") != std::string::npos)
+        tag_family = vpDetectorAprilTag::vpAprilTagFamily::TAG_36h10;
+      else if(tag_family_str.find("36h11") != std::string::npos)
+        tag_family = vpDetectorAprilTag::vpAprilTagFamily::TAG_36h11;
+      detector = new vpDetectorAprilTag(tag_family);
+    }
 #endif
 #endif
 

--- a/visp_auto_tracker/src/node.cpp
+++ b/visp_auto_tracker/src/node.cpp
@@ -25,6 +25,7 @@
 #else
 #  include <visp3/detection/vpDetectorDataMatrixCode.h>
 #  include <visp3/detection/vpDetectorQRCode.h>
+#  include <visp3/detection/vpDetectorAprilTag.h>
 #endif
 
 #include <visp_bridge/camera.h>
@@ -139,15 +140,19 @@ namespace visp_auto_tracker{
 #endif
 #else // ViSP >= 2.10.0. In that case we use the detectors from ViSP
     vpDetectorBase *detector = NULL;
-#if defined(VISP_HAVE_ZBAR) && defined(VISP_HAVE_DMTX)
+#if defined(VISP_HAVE_ZBAR) && !defined(VISP_HAVE_DMTX) && !defined(VISP_HAVE_APRILTAG)
+    detector = new vpDetectorQRCode;
+#elif defined(VISP_HAVE_DMTX) && !defined(VISP_HAVE_ZBAR) && !defined(VISP_HAVE_APRILTAG)
+    detector = new vpDetectorDataMatrixCode;
+#elif defined(VISP_HAVE_APRILTAG) && !defined(VISP_HAVE_ZBAR) && !defined(VISP_HAVE_DMTX)
+    detector = new vpDetectorAprilTag;
+#elif defined(VISP_HAVE_ZBAR) && defined(VISP_HAVE_DMTX)
     if (cmd_.get_detector_type() == CmdLine::ZBAR)
       detector = new vpDetectorQRCode;
     else if(cmd_.get_detector_type() == CmdLine::DMTX)
       detector = new vpDetectorDataMatrixCode;
-#elif defined(VISP_HAVE_ZBAR)
-    detector = new vpDetectorQRCode;
-#elif defined(VISP_HAVE_DMTX)
-    detector = new vpDetectorDataMatrixCode;
+    else if(cmd_.get_detector_type() == CmdLine::APRIL)
+      detector = new vpDetectorAprilTag;
 #endif
 #endif
 


### PR DESCRIPTION
Hello,

Here are some modifications to let the user be able to choose April Tags detector for [visp_auto_tracker](https://github.com/lagadic/vision_visp/tree/master/visp_auto_tracker).
(Issue #104)

I did it only in the case of `#if VISP_VERSION_INT >= VP_VERSION_INT(2,10,0)`, but I could have a look on how to do it in the other case, if necessary.

I am not sure what is the best way to let the user choose the tags family, but I will propose something in a next commit.