### PR TITLE
Fixed typo in CMakeLists.txt of visp_auto_tracker

### DIFF
--- a/visp_auto_tracker/CMakeLists.txt
+++ b/visp_auto_tracker/CMakeLists.txt
@@ -122,6 +122,8 @@ ExternalProject_Add(
   INSTALL_COMMAND ""
 )
 
+ExternalProject_Get_Property(external_bag DOWNLOADED_FILE)
+
 set(BAG_DIR ${CMAKE_CURRENT_BINARY_DIR}/bag)
 set(BAG_METADATA ${BAG_DIR}/metadata.yaml)
 set(BAG_DB ${BAG_DIR}/tutorial-qrcode-ros2.db3)


### PR DESCRIPTION
[FIX] Forgot to get the path to the downloaded file